### PR TITLE
Fix duplicated access point on results after selecting a point in map

### DIFF
--- a/Coastal/Classes/CCCCombinedViewController.m
+++ b/Coastal/Classes/CCCCombinedViewController.m
@@ -488,7 +488,7 @@ CCCPinAnnotationViewDelegate
 {
     MKMapRect mapRect = [self.view.hiddenMapView mapRectThatFits:self.view.mapView.visibleMapRect
                                                      edgePadding:UIEdgeInsetsMake(-60.0, 0.0, -75.0, 0.0)];
-    NSMutableArray *accessPoints = [self accessPointsWithinMapRect:mapRect].mutableCopy;
+    NSArray *accessPoints = [self accessPointsWithinMapRect:mapRect];
 
     NSArray *sortDescriptors = @[
                                  [[NSSortDescriptor alloc] initWithKey:kDistance
@@ -505,11 +505,9 @@ CCCPinAnnotationViewDelegate
         if ([selectedAnnotation isKindOfClass:[CCCPinAnnotation class]])
         {
             NSDictionary *selectedAccessPoint = ((CCCPinAnnotation *)selectedAnnotation).accessPoint;
-            NSUInteger selectedIndex = [accessPoints indexOfObjectPassingTest:^BOOL (NSDictionary *accessPoint, NSUInteger idx, BOOL *stop) {
-                return [accessPoint[kID] integerValue] == [selectedAccessPoint[kID] integerValue];
-            }];
+            NSUInteger selectedIndex = [[visibleAccessPoints valueForKey:kID] indexOfObject:selectedAccessPoint[kID]];
 
-            if (selectedIndex >= 0 && selectedIndex != NSNotFound)
+            if (selectedIndex != NSNotFound)
             {
                 [visibleAccessPoints removeObjectAtIndex:selectedIndex];
                 [visibleAccessPoints insertObject:selectedAccessPoint atIndex:0];


### PR DESCRIPTION
Fix a issue that happens on some cases when user select a access point and we move it to the top of the list but the previous existing access point is not removed from the results causing it to appear duplicated.